### PR TITLE
Remove duplicate activerecord dependency

### DIFF
--- a/foreigner.gemspec
+++ b/foreigner.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
- 
+
 Gem::Specification.new do |s|
   s.name = 'foreigner'
   s.version = '1.2.0'
@@ -17,5 +17,4 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w(README.rdoc)
   s.files = %w(MIT-LICENSE Rakefile README.rdoc) + Dir['lib/**/*.rb'] + Dir['test/**/*.rb']
   s.add_dependency('activerecord', '>= 3.0.0')
-  s.add_development_dependency('activerecord', '>= 3.1.0')
 end


### PR DESCRIPTION
The dulicate causes installation failures in recent versions of bundler, resulting in the following whenever bundler is used:

```
Could not find foreigner-1.2.0 in any of the sources
Run `bundle install` to install missing gems.
```
